### PR TITLE
LUT-33232 : Do not treat an unresolved component name as a new plugin (core7)

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -59,6 +59,26 @@ Par défaut, le plugin ne fait rien. Toutes les configurations sont définies da
 |  `liquibase.failOnError` | Arrêter sur une erreur SQL dans un changeset (true) ou continuer avec les changesets suivants (false)| true|
 
 
+# Ordre d'exécution : la directive d'en-tête runAfter
+
+Par défaut, liquibase exécute les fichiers SQL dans l'ordre alphabétique des chemins. Quand un plugin a besoin que ses scripts s'exécutent après ceux d'un autre plugin (typiquement pour insérer des lignes dans des tables créées par cet autre plugin), le contournement historique consistait à livrer le fichier SQL directement dans le répertoire de l'autre plugin. Cette pratique casse la résolution de version : l'inclusion du fichier est alors décidée par rapport à la version de l'autre plugin, jamais celle du propriétaire.
+
+La directive d'en-tête `runAfter` remplace cette pratique. Elle se déclare dans le bloc de commentaires de tête (avant le premier changeset) de n'importe quel script du plugin :
+
+```sql
+--liquibase formatted sql
+--lutece runAfter:genericattributes
+--changeset forms:init_db_generic_attributes_forms.sql
+INSERT INTO genatt_entry_type (id_type, title, ...) VALUES (1, 'Bouton radio', ...);
+```
+
+Tous les scripts du plugin déclarant (ici `forms`) sont alors ordonnés après tous les scripts du plugin cible (ici `genericattributes`), tout en restant physiquement dans le répertoire de leur propriétaire — la résolution de version reste donc correcte.
+
+* La directive a une portée plugin : une seule déclaration dans un seul fichier suffit pour tout le plugin.
+* Les directives se chaînent à n'importe quelle profondeur : si A déclare runAfter:B et B déclare runAfter:C, l'ordre résultant est C, puis B, puis A.
+* Les directives invalides (cibles en conflit dans un même plugin, cible inconnue ou sans script, auto-référence, implication de core, cycles de dépendances) sont ignorées avec un log ERROR et le plugin garde sa position naturelle.
+
+
 [Maven documentation and reports](https://dev.lutece.paris.fr/plugins/plugin-liquibase/)
 
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,26 @@ By default the plugin does nothing. All configurations are defined in the `liqui
 |  `liquibase.failOnError` | Stop on SQL error in a changeset (true) or continue with the next changesets (false)| true|
 
 
+# Script ordering: the runAfter header directive
+
+By default, liquibase executes the SQL files in alphabetical path order. When a plugin needs its scripts to run after those of another plugin (typically to insert rows into tables created by that other plugin), the historical workaround was to ship the SQL file directly in the other plugin's directory. This practice breaks version resolution: the inclusion of the file is then decided against the other plugin's version, never the owner's.
+
+The `runAfter` header directive replaces this practice. Declare it in the leading comment block (before the first changeset) of any script of the plugin:
+
+```sql
+--liquibase formatted sql
+--lutece runAfter:genericattributes
+--changeset forms:init_db_generic_attributes_forms.sql
+INSERT INTO genatt_entry_type (id_type, title, ...) VALUES (1, 'Radio button', ...);
+```
+
+All the scripts of the declaring plugin (here `forms`) are then ordered after all the scripts of the target plugin (here `genericattributes`), while the files physically stay in their owner's directory — so version resolution remains correct.
+
+* The directive is plugin-scoped: one declaration in a single file is enough for the whole plugin.
+* Directives chain to any depth: if A declares runAfter:B and B declares runAfter:C, the resulting order is C, then B, then A.
+* Invalid directives (conflicting targets inside one plugin, unknown or script-less target, self reference, involvement of core, dependency cycles) are ignored with an ERROR log and the plugin keeps its natural position.
+
+
 [Maven documentation and reports](https://dev.lutece.paris.fr/plugins/plugin-liquibase/)
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,31 @@
 			<artifactId>xml-apis</artifactId>
 			<version>1.4.01</version>
 		</dependency>
+		<!-- core7: explicit JUnit 5 (library-lutece-unit-testing is v8-only, version not managed by parent 7.0.2) -->
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<version>5.10.2</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>3.2.5</version>
+				<configuration>
+					<!-- surefire's default patterns also match Test*-prefixed classes,
+					     which makes it try to load TestIncludeAllFilter as a test class -->
+					<includes>
+						<include>**/*Test.java</include>
+					</includes>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 
 	<properties>
 		<componentName>liquibase</componentName>

--- a/src/java/db/changelog.xml
+++ b/src/java/db/changelog.xml
@@ -11,5 +11,5 @@
     http://www.liquibase.org/xml/ns/dbchangelog 
     http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.0.xsd
     ">
-	<includeAll path="sql" filter="fr.paris.lutece.plugins.liquibase.filters.TestIncludeAllFilter"></includeAll>
+	<includeAll path="sql" filter="fr.paris.lutece.plugins.liquibase.filters.TestIncludeAllFilter" resourceComparator="fr.paris.lutece.plugins.liquibase.filters.LuteceRunAfterComparator"></includeAll>
 </databaseChangeLog>

--- a/src/java/fr/paris/lutece/plugins/liquibase/LiquibaseRunnerContext.java
+++ b/src/java/fr/paris/lutece/plugins/liquibase/LiquibaseRunnerContext.java
@@ -45,9 +45,10 @@ public class LiquibaseRunnerContext
     
     private static final String LIQUIBASE_ACCEPT_SNAPSHOT_VERSIONS = "liquibase.accept.snapshot.versions";
     private static final String LIQUIBASE_ACCEPT_UNSTABLE_VERSIONS = "liquibase.accept.unstable.versions";
+    private static final String LIQUIBASE_SAFE_RUN = "liquibase.safeRun";
 
 
-    private static boolean liquibaseNeverRan, emptyDb, bAcceptSnapshotVersion, bAcceptUnstableVersion, bEnabledDryRun,bEnableMigrationMode;
+    private static boolean liquibaseNeverRan, emptyDb, bAcceptSnapshotVersion, bAcceptUnstableVersion, bEnabledDryRun,bEnableMigrationMode,bSafeRun;
     public static boolean isEmptyDb()
     {
         return emptyDb;
@@ -94,6 +95,7 @@ public class LiquibaseRunnerContext
         bAcceptUnstableVersion=  AppPropertiesService.getPropertyBoolean(LIQUIBASE_ACCEPT_UNSTABLE_VERSIONS, false);
         bEnabledDryRun=  AppPropertiesService.getPropertyBoolean("liquibase.dryrun", false);
         bEnableMigrationMode=  AppPropertiesService.getPropertyBoolean("liquibase.migration.mode", false);
+        bSafeRun=  AppPropertiesService.getPropertyBoolean(LIQUIBASE_SAFE_RUN, true);
         LiquibaseRunnerContext.connection = connection;
         final String firstRunRequest = AppPropertiesService.getProperty(SQL__FIRST_LIQUIBASE_RUN_EVER, "select count(*) FROM information_schema.tables where table_name='DATABASECHANGELOG';");
         liquibaseNeverRan = runQuery(firstRunRequest, r -> r.getInt(1)) == 0;
@@ -154,7 +156,30 @@ public class LiquibaseRunnerContext
 
 
     /**
-     * 
+     * Reports a SQL file whose path resolves to a component declared by no plugin descriptor
+     * (nor themes.&lt;name&gt;.version property).
+     *
+     * This is a packaging fault (LUT-33232) : the file's directory and the shipping artifact's descriptor disagree.
+     * When liquibase.safeRun is true (the default), startup is aborted before any changeset is executed
+     * (this method is called while liquibase parses the changelog, before execution).
+     * Otherwise the fault is only logged, and the caller excludes the file.
+     *
+     * @param path          the SQL file path
+     * @param componentName the unresolved component name derived from the path
+     */
+    public static void reportUnresolvedComponent(String path, String componentName)
+    {
+        AppLogService.error("LiquibaseRunner. SQL file {} resolves to component '{}' which is not declared by any plugin descriptor : file NOT included", path,
+                componentName);
+        if (bSafeRun)
+        {
+            throw new IllegalStateException("LiquibaseRunner : SQL file " + path + " resolves to undeclared component '" + componentName
+                    + "'. This is a packaging fault (see LUT-33232) : startup aborted because liquibase.safeRun=true. Set liquibase.safeRun=false to only exclude such files.");
+        }
+    }
+
+    /**
+     *
      * Looks the type of the last run script (create/init or update) in the DB.
      * 
      * 

--- a/src/java/fr/paris/lutece/plugins/liquibase/filters/LuteceRunAfterComparator.java
+++ b/src/java/fr/paris/lutece/plugins/liquibase/filters/LuteceRunAfterComparator.java
@@ -1,0 +1,255 @@
+package fr.paris.lutece.plugins.liquibase.filters;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import fr.paris.lutece.plugins.liquibase.PluginMeta;
+import fr.paris.lutece.portal.service.util.AppLogService;
+import fr.paris.lutece.utils.sql.SqlPathInfo;
+import liquibase.resource.ClassLoaderResourceAccessor;
+import liquibase.resource.Resource;
+
+/**
+ * Comparator for use in the liquibase changelog config (resourceComparator attribute of includeAll).
+ *
+ * Orders SQL files as liquibase does by default (alphabetical path order), except for plugins declaring
+ * an explicit ordering directive in the leading comment block of any of their scripts :
+ *
+ * <pre>
+ * --liquibase formatted sql
+ * --lutece runAfter:genericattributes
+ * --changeset author:id
+ * </pre>
+ *
+ * The directive is plugin-scoped : ALL the scripts of the declaring plugin are then ordered as if the
+ * plugin's directory lived under the target plugin's directory, AFTER all the target's own scripts, while
+ * physically staying in place. This replaces the fragile practice of placing a SQL file in another plugin's
+ * directory to control execution order, which breaks version resolution (LUT-33232) : with runAfter, paths
+ * still resolve to the true owner of each script.
+ *
+ * Directives chain to any depth : if A declares runAfter:B and B declares runAfter:C, the resulting order
+ * is C, then B, then A (locations are resolved recursively along the dependency graph). Invalid directives
+ * are ignored with an ERROR log and the plugin keeps its natural position : conflicting targets inside one
+ * plugin, unknown or script-less target, self reference, involvement of core, and dependency cycles
+ * (broken deterministically, plugins being resolved in name order).
+ *
+ * The directive must appear in the leading comment block, before the first non-comment line.
+ *
+ * Like the rest of this plugin, this class is deliberately not thread-safe : liquibase runs in the single
+ * startup thread. Instantiated by liquibase itself (no-arg constructor), outside any DI.
+ */
+public class LuteceRunAfterComparator implements Comparator<String>
+{
+    private static final String WEB_INF_CLASSES = "WEB-INF/classes/";
+    private static final Pattern RUN_AFTER_PATTERN = Pattern.compile("^--\\s*lutece\\b.*\\brunAfter:([\\p{Alnum}\\-]+)");
+    private static final int MAX_HEADER_LINES = 20;
+    private static final String CORE_PLUGIN_NAME = "core";
+    // '~' sorts after any alphanumeric, so relocated scripts land after the target's own files.
+    // FILE_MARKER sorts before AFTER_MARKER ("/" < "r"), so a relocated plugin's files always sort
+    // before the files of plugins relocated after IT (chained directives).
+    private static final String AFTER_MARKER = "/~runAfter/";
+    private static final String FILE_MARKER = "/~/";
+
+    /** normalized path -> sort key, for the files of relocated plugins only. Built on first use. */
+    private Map<String, String> relocatedKeys;
+
+    @Override
+    public int compare(String left, String right)
+    {
+        if (relocatedKeys == null)
+        {
+            relocatedKeys = buildRelocatedKeys();
+        }
+        // Liquibase stores resources in a TreeSet based on this comparator : returning 0 deduplicates
+        // the two forms of the same path (with and without WEB-INF/classes/), as the standard comparator
+        // does. Distinct normalized paths always yield distinct keys since the key embeds the whole path.
+        return keyOf(left).compareTo(keyOf(right));
+    }
+
+    private String keyOf(String path)
+    {
+        String normalized = normalize(path);
+        return relocatedKeys.getOrDefault(normalized, normalized);
+    }
+
+    private static String normalize(String path)
+    {
+        return path.replace(WEB_INF_CLASSES, "");
+    }
+
+    private Map<String, String> buildRelocatedKeys()
+    {
+        try (ClassLoaderResourceAccessor accessor = new ClassLoaderResourceAccessor())
+        {
+            return buildRelocatedKeys(accessor.search("sql", true));
+        } catch (Exception e)
+        {
+            AppLogService.error("LiquibaseRunner. Could not scan SQL files for runAfter directives : falling back to alphabetical order", e);
+            return new HashMap<>();
+        }
+    }
+
+    private Map<String, String> buildRelocatedKeys(List<Resource> resources) throws IOException
+    {
+        // single pass over every SQL file : owning plugin, directory prefix, runAfter directive
+        Map<String, String> basePrefixes = new HashMap<>();
+        Map<String, List<String>> componentFiles = new HashMap<>();
+        // TreeMap so that locations are resolved in name order : deterministic cycle breaking
+        Map<String, String> targets = new TreeMap<>();
+        Set<String> conflicting = new HashSet<>();
+        Set<String> seen = new HashSet<>();
+        for (Resource resource : resources)
+        {
+            String path = normalize(resource.getPath());
+            if (!path.endsWith(".sql") || !seen.add(path))
+                continue;
+            SqlPathInfo info = SqlPathInfo.parse(path);
+            // themes and unrecognized files keep their natural position
+            if (info == null || info.isTheme())
+                continue;
+            String component = info.getFullPluginName();
+            basePrefixes.putIfAbsent(component, directoryPrefix(path));
+            componentFiles.computeIfAbsent(component, k -> new ArrayList<>()).add(path);
+            String target = readRunAfterTarget(resource, path);
+            if (target == null)
+                continue;
+            String previous = targets.put(component, target);
+            if (previous != null && !previous.equals(target))
+            {
+                AppLogService.error("LiquibaseRunner. Plugin {} declares conflicting runAfter targets ({} and {}) : directives ignored", component, previous,
+                        target);
+                conflicting.add(component);
+            }
+        }
+        targets.keySet().removeAll(conflicting);
+
+        for (Iterator<Map.Entry<String, String>> iterator = targets.entrySet().iterator(); iterator.hasNext();)
+        {
+            Map.Entry<String, String> entry = iterator.next();
+            String component = entry.getKey();
+            String target = entry.getValue();
+            String error = null;
+            if (CORE_PLUGIN_NAME.equals(component) || CORE_PLUGIN_NAME.equals(target))
+                error = "core cannot take part in runAfter ordering";
+            else if (component.equals(target))
+                error = "a plugin cannot run after itself";
+            else if (PluginMeta.getPluginVersion(target) == null)
+                error = "no such plugin is declared";
+            else if (!basePrefixes.containsKey(target))
+                error = "the target plugin has no SQL script";
+            if (error != null)
+            {
+                AppLogService.error("LiquibaseRunner. runAfter:{} declared by plugin {} ignored : {}", target, component, error);
+                iterator.remove();
+            }
+        }
+
+        Map<String, String> locations = new HashMap<>();
+        for (String component : new ArrayList<>(targets.keySet()))
+        {
+            resolveLocation(component, targets, basePrefixes, locations, new LinkedHashSet<>());
+        }
+
+        Map<String, String> keys = new HashMap<>();
+        for (Map.Entry<String, String> entry : targets.entrySet())
+        {
+            String component = entry.getKey();
+            String location = locations.get(component);
+            AppLogService.info("LiquibaseRunner. Scripts of plugin {} will run after those of plugin {}", component, entry.getValue());
+            for (String path : componentFiles.get(component))
+            {
+                keys.put(path, location + FILE_MARKER + path);
+            }
+        }
+        return keys;
+    }
+
+    /**
+     * Resolves the effective location of a plugin : its own directory, or, when it declares a (valid)
+     * runAfter directive, a virtual directory sorting right after its target's effective location.
+     * Cycles are broken at the plugin closing the loop, whose directive is discarded.
+     */
+    private String resolveLocation(String component, Map<String, String> targets, Map<String, String> basePrefixes, Map<String, String> locations,
+            Set<String> visiting)
+    {
+        String location = locations.get(component);
+        if (location != null)
+            return location;
+        String target = targets.get(component);
+        if (target == null)
+        {
+            location = basePrefixes.get(component);
+        }
+        else if (!visiting.add(component))
+        {
+            AppLogService.error("LiquibaseRunner. Cycle detected in runAfter directives at plugin {} (chain : {}) : directive ignored", component, visiting);
+            targets.remove(component);
+            location = basePrefixes.get(component);
+        }
+        else
+        {
+            String parentLocation = resolveLocation(target, targets, basePrefixes, locations, visiting);
+            visiting.remove(component);
+            String existing = locations.get(component);
+            // the recursion may have broken a cycle at this very component : its location is already settled
+            if (existing != null)
+                return existing;
+            location = parentLocation + AFTER_MARKER + component;
+        }
+        locations.put(component, location);
+        return location;
+    }
+
+    /**
+     * Returns the plugin's SQL directory : the path minus the (core|plugin|upgrade)/file.sql trailing part.
+     */
+    private static String directoryPrefix(String path)
+    {
+        int last = path.lastIndexOf('/');
+        int previous = last > 0 ? path.lastIndexOf('/', last - 1) : -1;
+        return previous > 0 ? path.substring(0, previous) : path.substring(0, Math.max(last, 0));
+    }
+
+    private String readRunAfterTarget(Resource resource, String path)
+    {
+        try (InputStream stream = resource.openInputStream())
+        {
+            BufferedReader reader = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8));
+            String line;
+            int count = 0;
+            while ((line = reader.readLine()) != null && count++ < MAX_HEADER_LINES)
+            {
+                String trimmed = line.trim();
+                if (!trimmed.isEmpty() && !trimmed.startsWith("--"))
+                {
+                    // past the leading comment block : the directive must appear before any SQL
+                    return null;
+                }
+                Matcher matcher = RUN_AFTER_PATTERN.matcher(trimmed);
+                if (matcher.find())
+                {
+                    return matcher.group(1);
+                }
+            }
+        } catch (IOException e)
+        {
+            AppLogService.error("LiquibaseRunner. Could not read header of " + path, e);
+        }
+        return null;
+    }
+}

--- a/src/java/fr/paris/lutece/plugins/liquibase/filters/TestIncludeAllFilter.java
+++ b/src/java/fr/paris/lutece/plugins/liquibase/filters/TestIncludeAllFilter.java
@@ -36,8 +36,20 @@ public class TestIncludeAllFilter implements IncludeAllFilter
         {
             AppLogService.debug("LiquibaseRunner testing file with info " + info);
             final String pluginName = info.getFullPluginName();
+            final String componentName = info.isTheme() ? info.getTheme() : pluginName;
+            // LUT-33232 : resolve the declared version BEFORE deciding anything.
+            // A path resolving to a component that no descriptor (or themes.<name>.version property) declares
+            // is a packaging fault, NOT a new plugin : a genuinely new plugin always ships its descriptor.
+            // Treating it as new used to run create_db_* scripts (and their DROP TABLE) on populated databases.
+            final String declaredVersion = info.isTheme() ? AppPropertiesService.getProperty("themes." + info.getTheme() + ".version")
+                    : PluginMeta.getPluginVersion(pluginName);
+            if (declaredVersion == null)
+            {
+                LiquibaseRunnerContext.reportUnresolvedComponent(changeLogPath, componentName);
+                include = false;
+            }
             // empty DB : only "create/init" files
-            if (LiquibaseRunnerContext.isEmptyDb())
+            else if (LiquibaseRunnerContext.isEmptyDb())
             {
                 include = info.isCreate();
                 if(include)
@@ -87,23 +99,10 @@ public class TestIncludeAllFilter implements IncludeAllFilter
                     AppLogService.error("version retrieve failed for plugin " + pluginName, e);
                 }
             }
-            // in all cases, store the current version in the datastore
-            if(!info.isTheme())
+            // in all cases (except unresolved components, excluded above), store the current version in the datastore
+            if (declaredVersion != null)
             {
-                //cas plugin,module,core
-                String pluginVersion=PluginMeta.getPluginVersion(pluginName);
-                if (pluginVersion == null)
-                    AppLogService.error("LiquibaseRunner. No plugin metadata for " + pluginName);
-                else
-                    LiquibaseRunnerContext.setComponentVersion(pluginName, pluginVersion,false);
-            }
-            else
-            {
-                String themeVersion=AppPropertiesService.getProperty("themes."+info.getTheme()+".version");
-                if (themeVersion == null)
-                    AppLogService.error("LiquibaseRunner. No theme metadata for " + info.getTheme());
-                else
-                    LiquibaseRunnerContext.setComponentVersion(info.getTheme(), themeVersion,true);
+                LiquibaseRunnerContext.setComponentVersion(componentName, declaredVersion, info.isTheme());
             }
         }
         AppLogService.info("LiquibaseRunner : file {} {}included", changeLogPath, include ? "" : "NOT ");

--- a/src/site/fr/xdoc/index.xml
+++ b/src/site/fr/xdoc/index.xml
@@ -141,5 +141,35 @@
 					</table>
 				</subsection>
 			</section>
+			<section name="Ordre d'exécution : la directive d'en-tête runAfter">
+				<p>
+					Par défaut, liquibase exécute les fichiers SQL dans l'ordre alphabétique des chemins. Quand un
+					plugin a besoin que ses scripts s'exécutent après ceux d'un autre plugin (typiquement pour insérer
+					des lignes dans des tables créées par cet autre plugin), le contournement historique consistait à
+					livrer le fichier SQL directement dans le répertoire de l'autre plugin. Cette pratique casse la
+					résolution de version : l'inclusion du fichier est alors décidée par rapport à la version de
+					l'autre plugin, jamais celle du propriétaire.
+				</p>
+				<p>
+					La directive d'en-tête <code>runAfter</code> remplace cette pratique. Elle se déclare dans le bloc
+					de commentaires de tête (avant le premier changeset) de n'importe quel script du plugin :
+				</p>
+				<pre>
+--liquibase formatted sql
+--lutece runAfter:genericattributes
+--changeset forms:init_db_generic_attributes_forms.sql
+INSERT INTO genatt_entry_type (id_type, title, ...) VALUES (1, 'Bouton radio', ...);
+				</pre>
+				<p>
+					Tous les scripts du plugin déclarant (ici <code>forms</code>) sont alors ordonnés après tous les
+					scripts du plugin cible (ici <code>genericattributes</code>), tout en restant physiquement dans le
+					répertoire de leur propriétaire — la résolution de version reste donc correcte.
+				</p>
+				<ul>
+					<li>La directive a une portée plugin : une seule déclaration dans un seul fichier suffit pour tout le plugin.</li>
+					<li>Les directives se chaînent à n'importe quelle profondeur : si A déclare runAfter:B et B déclare runAfter:C, l'ordre résultant est C, puis B, puis A.</li>
+					<li>Les directives invalides (cibles en conflit dans un même plugin, cible inconnue ou sans script, auto-référence, implication de core, cycles de dépendances) sont ignorées avec un log ERROR et le plugin garde sa position naturelle.</li>
+				</ul>
+			</section>
 	</body>
 </document>

--- a/src/site/xdoc/index.xml
+++ b/src/site/xdoc/index.xml
@@ -142,5 +142,34 @@
 				</subsection>
 			</section>
 			
+			<section name="Script ordering : the runAfter header directive">
+				<p>
+					By default, liquibase executes the SQL files in alphabetical path order. When a plugin needs its
+					scripts to run after those of another plugin (typically to insert rows into tables created by that
+					other plugin), the historical workaround was to ship the SQL file directly in the other plugin's
+					directory. This practice breaks version resolution : the inclusion of the file is then decided
+					against the other plugin's version, never the owner's.
+				</p>
+				<p>
+					The <code>runAfter</code> header directive replaces this practice. Declare it in the leading comment
+					block (before the first changeset) of any script of the plugin :
+				</p>
+				<pre>
+--liquibase formatted sql
+--lutece runAfter:genericattributes
+--changeset forms:init_db_generic_attributes_forms.sql
+INSERT INTO genatt_entry_type (id_type, title, ...) VALUES (1, 'Radio button', ...);
+				</pre>
+				<p>
+					All the scripts of the declaring plugin (here <code>forms</code>) are then ordered after all the
+					scripts of the target plugin (here <code>genericattributes</code>), while the files physically stay
+					in their owner's directory — so version resolution remains correct.
+				</p>
+				<ul>
+					<li>The directive is plugin-scoped : one declaration in a single file is enough for the whole plugin.</li>
+					<li>Directives chain to any depth : if A declares runAfter:B and B declares runAfter:C, the resulting order is C, then B, then A.</li>
+					<li>Invalid directives (conflicting targets inside one plugin, unknown or script-less target, self reference, involvement of core, dependency cycles) are ignored with an ERROR log and the plugin keeps its natural position.</li>
+				</ul>
+			</section>
 	</body>
 </document>

--- a/src/test/java/fr/paris/lutece/plugins/liquibase/filters/LuteceRunAfterComparatorTest.java
+++ b/src/test/java/fr/paris/lutece/plugins/liquibase/filters/LuteceRunAfterComparatorTest.java
@@ -1,0 +1,115 @@
+package fr.paris.lutece.plugins.liquibase.filters;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import fr.paris.lutece.plugins.liquibase.PluginMeta;
+
+/**
+ * Validates the topological ordering produced by {@link LuteceRunAfterComparator} from runAfter directives
+ * declared in the headers of the SQL fixtures under src/test/resources/sql/plugins :
+ *
+ * <ul>
+ * <li>aaa declares runAfter:bbb (in its create script only), bbb declares runAfter:ccc, ccc declares nothing
+ * : the expected order is ccc, bbb, aaa — the exact opposite of the alphabetical order liquibase would use</li>
+ * <li>mmm declares nothing and keeps its natural position</li>
+ * <li>qqq declares runAfter:doesnotexist : invalid target, natural position kept</li>
+ * <li>xxx and yyy declare runAfter on each other : cycle, broken deterministically without failing</li>
+ * </ul>
+ */
+public class LuteceRunAfterComparatorTest
+{
+    private static final String AAA_CREATE = "sql/plugins/aaa/plugin/create_db_aaa.sql";
+    private static final String AAA_UPDATE = "sql/plugins/aaa/upgrade/update_db_aaa-1.0.0-1.1.0.sql";
+    private static final String BBB_CREATE = "sql/plugins/bbb/plugin/create_db_bbb.sql";
+    private static final String CCC_CREATE = "sql/plugins/ccc/plugin/create_db_ccc.sql";
+    private static final String CCC_UPDATE = "sql/plugins/ccc/upgrade/update_db_ccc-1.0.0-1.1.0.sql";
+    private static final String MMM_CREATE = "sql/plugins/mmm/plugin/create_db_mmm.sql";
+    private static final String QQQ_CREATE = "sql/plugins/qqq/plugin/create_db_qqq.sql";
+    private static final String XXX_CREATE = "sql/plugins/xxx/plugin/create_db_xxx.sql";
+    private static final String YYY_CREATE = "sql/plugins/yyy/plugin/create_db_yyy.sql";
+
+    @BeforeAll
+    public static void declarePlugins()
+    {
+        // runAfter targets must resolve to declared plugins : populate the map preloadMeta() would fill
+        for (String plugin : Arrays.asList("aaa", "bbb", "ccc", "mmm", "qqq", "xxx", "yyy"))
+        {
+            PluginMeta.getPluginsMeta().put(plugin, "1.0.0");
+        }
+    }
+
+    private List<String> sortedFixtures()
+    {
+        // deliberately fed out of order
+        List<String> paths = new ArrayList<>(Arrays.asList(AAA_UPDATE, MMM_CREATE, CCC_UPDATE, BBB_CREATE, YYY_CREATE, AAA_CREATE, QQQ_CREATE, XXX_CREATE,
+                CCC_CREATE));
+        paths.sort(new LuteceRunAfterComparator());
+        return paths;
+    }
+
+    private static void assertBefore(List<String> sorted, String first, String second)
+    {
+        int firstIndex = sorted.indexOf(first);
+        int secondIndex = sorted.indexOf(second);
+        assertTrue(firstIndex >= 0, first + " missing from " + sorted);
+        assertTrue(secondIndex >= 0, second + " missing from " + sorted);
+        assertTrue(firstIndex < secondIndex, first + " should sort before " + second + " but order was " + sorted);
+    }
+
+    @Test
+    public void chainedRunAfterReversesAlphabeticalOrder()
+    {
+        List<String> sorted = sortedFixtures();
+        // chain aaa -> bbb -> ccc : execution order must be ccc, then bbb, then aaa
+        assertBefore(sorted, CCC_CREATE, BBB_CREATE);
+        assertBefore(sorted, CCC_UPDATE, BBB_CREATE);
+        assertBefore(sorted, BBB_CREATE, AAA_CREATE);
+        // ccc's own scripts keep their internal alphabetical order
+        assertBefore(sorted, CCC_CREATE, CCC_UPDATE);
+    }
+
+    @Test
+    public void directiveIsPluginScoped()
+    {
+        List<String> sorted = sortedFixtures();
+        // aaa's update script declares no directive itself, but the whole plugin is relocated
+        assertBefore(sorted, BBB_CREATE, AAA_UPDATE);
+        // and aaa's scripts keep their internal alphabetical order
+        assertBefore(sorted, AAA_CREATE, AAA_UPDATE);
+    }
+
+    @Test
+    public void unrelatedPluginsKeepTheirNaturalPositions()
+    {
+        List<String> sorted = sortedFixtures();
+        // mmm and qqq (invalid target, directive ignored) stay in plain alphabetical order,
+        // after the whole ccc chain ('~' sorts after any alphanumeric) and before xxx/yyy
+        assertBefore(sorted, AAA_UPDATE, MMM_CREATE);
+        assertBefore(sorted, MMM_CREATE, QQQ_CREATE);
+        assertBefore(sorted, QQQ_CREATE, XXX_CREATE);
+    }
+
+    @Test
+    public void cycleIsBrokenDeterministicallyWithoutFailing()
+    {
+        List<String> sorted = sortedFixtures();
+        // xxx <-> yyy : plugins are resolved in name order, so the cycle is broken at xxx
+        // (its directive is discarded, it keeps its natural position) and yyy lands after it
+        assertBefore(sorted, XXX_CREATE, YYY_CREATE);
+        assertEquals(9, sorted.size());
+    }
+
+    @Test
+    public void bothFormsOfTheSamePathCompareEqualForTreeSetDeduplication()
+    {
+        assertEquals(0, new LuteceRunAfterComparator().compare("WEB-INF/classes/" + CCC_CREATE, CCC_CREATE));
+    }
+}

--- a/src/test/resources/sql/plugins/aaa/plugin/create_db_aaa.sql
+++ b/src/test/resources/sql/plugins/aaa/plugin/create_db_aaa.sql
@@ -1,0 +1,4 @@
+--liquibase formatted sql
+--lutece runAfter:bbb
+--changeset aaa:create_db_aaa
+CREATE TABLE aaa_data (id INT);

--- a/src/test/resources/sql/plugins/aaa/upgrade/update_db_aaa-1.0.0-1.1.0.sql
+++ b/src/test/resources/sql/plugins/aaa/upgrade/update_db_aaa-1.0.0-1.1.0.sql
@@ -1,0 +1,3 @@
+--liquibase formatted sql
+--changeset aaa:update_db_aaa-1.0.0-1.1.0
+ALTER TABLE aaa_data ADD COLUMN label VARCHAR(50);

--- a/src/test/resources/sql/plugins/bbb/plugin/create_db_bbb.sql
+++ b/src/test/resources/sql/plugins/bbb/plugin/create_db_bbb.sql
@@ -1,0 +1,4 @@
+--liquibase formatted sql
+--lutece runAfter:ccc
+--changeset bbb:create_db_bbb
+CREATE TABLE bbb_data (id INT);

--- a/src/test/resources/sql/plugins/ccc/plugin/create_db_ccc.sql
+++ b/src/test/resources/sql/plugins/ccc/plugin/create_db_ccc.sql
@@ -1,0 +1,3 @@
+--liquibase formatted sql
+--changeset ccc:create_db_ccc
+CREATE TABLE ccc_data (id INT);

--- a/src/test/resources/sql/plugins/ccc/upgrade/update_db_ccc-1.0.0-1.1.0.sql
+++ b/src/test/resources/sql/plugins/ccc/upgrade/update_db_ccc-1.0.0-1.1.0.sql
@@ -1,0 +1,3 @@
+--liquibase formatted sql
+--changeset ccc:update_db_ccc-1.0.0-1.1.0
+ALTER TABLE ccc_data ADD COLUMN label VARCHAR(50);

--- a/src/test/resources/sql/plugins/mmm/plugin/create_db_mmm.sql
+++ b/src/test/resources/sql/plugins/mmm/plugin/create_db_mmm.sql
@@ -1,0 +1,3 @@
+--liquibase formatted sql
+--changeset mmm:create_db_mmm
+CREATE TABLE mmm_data (id INT);

--- a/src/test/resources/sql/plugins/qqq/plugin/create_db_qqq.sql
+++ b/src/test/resources/sql/plugins/qqq/plugin/create_db_qqq.sql
@@ -1,0 +1,4 @@
+--liquibase formatted sql
+--lutece runAfter:doesnotexist
+--changeset qqq:create_db_qqq
+CREATE TABLE qqq_data (id INT);

--- a/src/test/resources/sql/plugins/xxx/plugin/create_db_xxx.sql
+++ b/src/test/resources/sql/plugins/xxx/plugin/create_db_xxx.sql
@@ -1,0 +1,4 @@
+--liquibase formatted sql
+--lutece runAfter:yyy
+--changeset xxx:create_db_xxx
+CREATE TABLE xxx_data (id INT);

--- a/src/test/resources/sql/plugins/yyy/plugin/create_db_yyy.sql
+++ b/src/test/resources/sql/plugins/yyy/plugin/create_db_yyy.sql
@@ -1,0 +1,4 @@
+--liquibase formatted sql
+--lutece runAfter:xxx
+--changeset yyy:create_db_yyy
+CREATE TABLE yyy_data (id INT);


### PR DESCRIPTION
## LUT-33232 (backport core7) — Do not treat an unresolved component as a new plugin + explicit runAfter ordering

Ticket: https://dev.lutece.paris.fr/bugtracker/issues/33232
Backport of the develop branch fix (see companion PR targeting `develop`).

### Content
- Clean cherry-pick of the 3 LUT-33232 commits (no conflicts).
- One core7-specific adaptation: `library-lutece-unit-testing` (v8-only, version not managed by parent POM 7.0.2) replaced by an explicit `org.junit.jupiter:junit-jupiter:5.10.2` test dependency + explicit surefire 3.2.5 (JUnit 5 support). The 5 unit tests pass under JDK 11.

### Validation (local, Lutece 7 site under Tomcat 9 with forms 3.1.6-SNAPSHOT + genericattributes 2.4.12-SNAPSHOT)
- Bug reproduced with vanilla develop_core7: fake undeclared component destroyed populated data (DROP TABLE executed, changeset recorded, only a non-blocking ERROR).
- With the backport: startup aborted with an explicit IllegalStateException (safeRun=true) / file excluded (safeRun=false), data intact.